### PR TITLE
Made a property counting the effective satellites for a faction.

### DIFF
--- a/src/player-data.spec.ts
+++ b/src/player-data.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import "mocha";
 import PlayerData from "./player-data";
-import { Resource, BrainstoneArea } from "./enums";
+import { Resource, BrainstoneArea, Building } from "./enums";
 
 describe("PlayerData", () => {
   it("should export to JSON", () => {
@@ -69,6 +69,21 @@ describe("PlayerData", () => {
       expect(data.power.area3).to.equal(2);
       expect(data.brainstone).to.equal(BrainstoneArea.Area3);
       expect(charged).to.equal(5);
+    });
+  });
+
+  describe("counting satellites", () => {
+    it("should return the amount of satellites for non-Ivits factions", () => {
+      const data = new PlayerData();
+      data.satellites = 4;
+      expect(data.effectiveSatellites).to.equal(4);
+    });
+
+    it("should count the Ivits' space stations", () => {
+      const data = new PlayerData();
+      data.satellites = 4;
+      data.buildings[Building.SpaceStation] = 6;
+      expect(data.effectiveSatellites).to.equal(10);
     });
   });
 });

--- a/src/player-data.ts
+++ b/src/player-data.ts
@@ -41,6 +41,11 @@ export default class PlayerData extends EventEmitter {
   } = fromPairs(Object.values(Building).map((bld) => [bld, 0])) as any;
 
   satellites = 0;
+
+  get effectiveSatellites() {
+    return this.satellites + this.buildings[Building.SpaceStation];
+  }
+
   research: {
     [key in ResearchField]: number;
   } = {

--- a/src/player.ts
+++ b/src/player.ts
@@ -802,7 +802,7 @@ export default class Player extends EventEmitter {
           (hex) => hex.colonizedBy(this.player) && hex.belongsToFederationOf(this.player)
         ).length;
       case Condition.Satellite:
-        return this.data.satellites + this.data.buildings[Building.SpaceStation];
+        return this.data.effectiveSatellites;
       case Condition.StructureValue:
         return sum(this.data.occupied.map((hex) => this.buildingValue(hex, { federation: true })));
       case Condition.StructureFedValue:


### PR DESCRIPTION
As we are now displaying the satellites on the faction board, it might be convinient to have a reusable function that returns the correct count. For the final scoring, Ivits' space stations were already counted. However, these were not displayed on the faction board. Both can now call the property on player data.

Back-end for https://github.com/boardgamers/gaia-viewer/issues/160